### PR TITLE
Add displayName of wrapped component to connect.js

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -1,27 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const connect = (mapProps = (p => p)) => Component => {
+const connect = (mapProps = p => p) => Component => {
   class Connected extends React.Component {
-    render () {
+    render() {
       const mapped = mapProps(this.context.state)
 
       return (
-        <Component
-          {...this.props}
-          {...mapped}
-          update={this.context.update}
-        />
+        <Component {...this.props} {...mapped} update={this.context.update} />
       )
     }
   }
 
+  Connected.displayName = `Connected(${getDisplayName(Component)})`
   Connected.contextTypes = {
     update: PropTypes.func.isRequired,
-    state: PropTypes.object.isRequired
+    state: PropTypes.object.isRequired,
   }
 
   return Connected
 }
+
+const getDisplayName = Component =>
+  Component.displayName || Component.name || 'Component'
 
 export default connect


### PR DESCRIPTION
This is a really cool project, thanks for sharing it! I find it helpful to have the wrapped component's display name visible in the HOC's name in the dev tools. Thought I'd try contributing... 